### PR TITLE
enlever le mot "pointeur" (vers les balises td)

### DIFF
--- a/_tutorials/tutorial2.md
+++ b/_tutorials/tutorial2.md
@@ -132,7 +132,7 @@ n'est pas chargé.
    propriété. Il est plus pratique d'avoir un tableau JavaScript à
    deux dimensions qui pointe vers les cases (les `<td>`) du
    plateau. Modifiez la double boucle `for` de sorte à remplir un
-   tableau à deux dimensions avec des pointeurs vers les
+   tableau à deux dimensions avec les 
    balises `td` du plateau. Cet exemple pourrait vous aider.
    
    {% include codepen.md pen="myXGeZ" tab="js" height="250" %}


### PR DESCRIPTION
La moitié des élèves n'a pas compris ce vocable de pointeur (qui ne me semble pas très adapté ici, personne ne parle de pointeur en javascript) et ça les bloque.