### PR TITLE
Make the db private

### DIFF
--- a/_tutorials/accounts.md
+++ b/_tutorials/accounts.md
@@ -56,13 +56,14 @@ database with the tables we need.
    var knex = require('knex')({
        client: 'sqlite3',
        connection: {
-           filename: "./db.sqlite3"
+           filename: ".data/db.sqlite3"
        },
        debug: true,
    });
    ```
    
-This code creates a SQLite file named `db.sqlite3`, and initiates a
+This code creates a SQLite file named `db.sqlite3` in the folder `.data` (which is
+a "private place" in Glitch), and initiates a
 connection. We can query the connection by operating on the `knex`
 object. For example, to create a SQL statement, we can run
 


### PR DESCRIPTION
From the Glitch's FAQ:
How do you store secrets/credentials or private data?

.env is a secure environment config section in your projects, useful for storing API keys and app credentials. Only invited collaborators are able to see the contents of your .env file. So anonymous viewers or logged-in users who haven’t been invited to your project can’t see them. When remixing an app the values are cleared so they’re not copied across.

In addition, creating a folder called .data is a safe place to store your data files. This folder isn’t copied across when a project is remixed.